### PR TITLE
add upgrade/4, remove build_request_headers/0

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -10,9 +10,7 @@ do_it = fn ->
       protocols: [:http2]
     )
 
-  req_headers = [{":protocol", "websocket"}, {":scheme", "http"}, {":path", "/"}]# | Mint.WebSocket.build_request_headers()]
-  #req_headers = []
-  {:ok, conn, ref} = Mint.HTTP.request(conn, "CONNECT", "/", req_headers, :stream)
+  {:ok, conn, ref} = Mint.WebSocket.upgrade(conn, "/", [])
 
   {:ok, conn, []} = Mint.HTTP.stream(conn, receive(do: (message -> message)))
 
@@ -21,7 +19,7 @@ do_it = fn ->
   {:ok, conn, [{:status, ^ref, status}, {:headers, ^ref, resp_headers}]} =
     Mint.HTTP.stream(conn, http_get_message)
 
-  {:ok, conn, websocket} = Mint.WebSocket.new(conn, ref, status, req_headers, resp_headers)
+  {:ok, conn, websocket} = Mint.WebSocket.new(conn, ref, status, resp_headers)
 
   {:ok, websocket, data} = Mint.WebSocket.encode(websocket, {:text, "hello world"})
   {:ok, conn} = Mint.HTTP.stream_request_body(conn, ref, data)

--- a/lib/mint/web_socket.ex
+++ b/lib/mint/web_socket.ex
@@ -5,12 +5,15 @@ defmodule Mint.WebSocket do
 
   require __MODULE__.Frame, as: Frame
   alias __MODULE__.Utils
+  alias Mint.WebSocketError
 
   @type t :: %__MODULE__{}
   defstruct extensions: MapSet.new(),
             fragments: [],
             private: %{},
             buffer: <<>>
+
+  @type error :: Mint.Types.error() | WebSocketError.t()
 
   defguardp is_frame(frame)
             when frame in [:ping, :pong, :close] or
@@ -29,38 +32,78 @@ defmodule Mint.WebSocket do
           | :close
           | {:close, code :: non_neg_integer(), reason :: binary()}
 
-  @spec build_request_headers(Keyword.t()) :: Mint.Types.headers()
-  def build_request_headers(_opts \\ []) do
-    Utils.random_nonce()
-    |> Utils.headers()
+  @doc """
+  Requests that a connection be upgraded to the WebSocket protocol
+
+  This function wraps `Mint.HTTP.request/5` to provide a single interface
+  for bootstrapping an upgrade for HTTP/1 and HTTP/2 connections.
+
+  For HTTP/1 connections, this function performs a GET request with
+  WebSocket-specific headers. For HTTP/2 connections, this function performs
+  an extended CONNECT request which opens a stream to be used for the WebSocket
+  connection.
+  """
+  @spec upgrade(
+          conn :: Mint.HTTP.t(),
+          path :: String.t(),
+          headers :: Mint.Types.headers(),
+          # maybe t:Keyword.t/0, will hold extensions in the future
+          opts :: list()
+        ) :: {:ok, Mint.HTTP.t(), Mint.Types.request_ref()} | {:error, Mint.HTTP.t(), error()}
+  def upgrade(conn, path, headers, opts \\ [])
+
+  def upgrade(%Mint.HTTP1{} = conn, path, headers, _opts) do
+    nonce = Utils.random_nonce()
+    headers = Utils.headers(nonce) ++ headers
+    conn = put_in(conn.private[:sec_websocket_key], nonce)
+
+    Mint.HTTP.request(conn, "GET", path, headers, nil)
   end
 
-  @spec new(Mint.HTTP.t(), reference(), pos_integer(), Mint.Types.headers(), Mint.Types.headers()) ::
-          {:ok, Mint.HTTP.t(), t(), [Mint.Types.response()]} | {:error, Mint.HTTP.t(), any()}
-  def new(%Mint.HTTP1{} = conn, _request_ref, status, _request_headers, _response_headers) when status != 101 do
-    {:error, conn, :connection_not_upgraded}
+  def upgrade(
+        %Mint.HTTP2{server_settings: %{enable_connect_protocol: true}} = conn,
+        path,
+        headers,
+        _opts
+      ) do
+    headers = [
+      {":scheme", conn.scheme},
+      {":path", path},
+      {":protocol", "websocket"}
+      | headers
+    ]
+
+    Mint.HTTP.request(conn, "CONNECT", path, headers, :stream)
   end
 
-  def new(%Mint.HTTP1{} = conn, request_ref, _status, request_headers, response_headers) do
-    with :ok <- Utils.check_accept_nonce(request_headers, response_headers) do
+  def upgrade(%Mint.HTTP2{} = conn, _path, _headers, _opts) do
+    {:error, conn, %WebSocketError{reason: :extended_connect_disabled}}
+  end
+
+  @spec new(Mint.HTTP.t(), reference(), pos_integer(), Mint.Types.headers()) ::
+          {:ok, Mint.HTTP.t(), t(), [Mint.Types.response()]} | {:error, Mint.HTTP.t(), error()}
+  def new(%Mint.HTTP1{} = conn, _request_ref, status, _response_headers)
+      when status != 101 do
+    {:error, conn, %WebSocketError{reason: :connection_not_upgraded}}
+  end
+
+  def new(%Mint.HTTP1{} = conn, request_ref, _status, response_headers) do
+    with :ok <- Utils.check_accept_nonce(conn.private[:sec_websocket_key], response_headers) do
       conn = re_open_request(conn, request_ref)
 
-      websocket = %__MODULE__{
-        extensions: Utils.common_extensions(request_headers, response_headers)
-      }
-
-      {:ok, conn, websocket}
+      {:ok, conn, %__MODULE__{}}
     else
       {:error, reason} -> {:error, conn, reason}
     end
   end
 
-  def new(%Mint.HTTP2{} = conn, _request_ref, _status, request_headers, response_headers) do
-    websocket = %__MODULE__{
-      extensions: Utils.common_extensions(request_headers, response_headers)
-    }
+  def new(%Mint.HTTP2{} = conn, _request_ref, status, _response_headers)
+      when status in 200..299 do
+    {:ok, conn, %__MODULE__{}}
+  end
 
-    {:ok, conn, websocket}
+  def new(%Mint.HTTP2{} = conn, _request_ref, _status, _response_headers) do
+    {:error, conn, %WebSocketError{reason: :connection_not_upgraded}}
   end
 
   @spec encode(t(), frame()) :: {:ok, t(), binary()} | {:error, t(), any()}

--- a/lib/mint/web_socket/utils.ex
+++ b/lib/mint/web_socket/utils.ex
@@ -17,11 +17,14 @@ defmodule Mint.WebSocket.Utils do
     ]
   end
 
-  @spec check_accept_nonce(Mint.Types.headers(), Mint.Types.headers()) ::
+  @spec check_accept_nonce(binary() | nil, Mint.Types.headers()) ::
           :ok | {:error, :invalid_nonce}
-  def check_accept_nonce(request_headers, response_headers) do
-    with {:ok, request_nonce} <- fetch_header(request_headers, "sec-websocket-key"),
-         {:ok, response_nonce} <- fetch_header(response_headers, "sec-websocket-accept"),
+  def check_accept_nonce(nil, _response_headers) do
+    {:error, :invalid_nonce}
+  end
+
+  def check_accept_nonce(request_nonce, response_headers) do
+    with {:ok, response_nonce} <- fetch_header(response_headers, "sec-websocket-accept"),
          true <- valid_accept_nonce?(request_nonce, response_nonce) do
       :ok
     else

--- a/lib/mint/web_socket_error.ex
+++ b/lib/mint/web_socket_error.ex
@@ -1,0 +1,31 @@
+defmodule Mint.WebSocketError do
+  @moduledoc """
+  Represents an error in the WebSocket protocol
+
+  The `Mint.WebSocketError` struct is an exception, so it can be raised as
+  any other exception.
+  """
+
+  reason_type =
+    quote do
+      :extended_connect_disabled
+      | :connection_not_upgraded
+    end
+
+  @type t :: %__MODULE__{reason: unquote(reason_type) | term()}
+
+  defexception [:reason]
+
+  @impl Exception
+  def message(%__MODULE__{reason: reason}) do
+    format_reason(reason)
+  end
+
+  defp format_reason(:extended_connect_disabled) do
+    "extended CONNECT method not enabled"
+  end
+
+  defp format_reason(:connection_not_upgraded) do
+    "connection not upgraded by remote"
+  end
+end

--- a/test/fixtures/autobahn_client.ex
+++ b/test/fixtures/autobahn_client.ex
@@ -64,14 +64,14 @@ defmodule AutobahnClient do
     :ok = flush()
     host = System.get_env("FUZZINGSERVER_HOST") || "localhost"
     {:ok, conn} = Mint.HTTP.connect(:http, host, 9001)
-    req_headers = Mint.WebSocket.build_request_headers()
-    {:ok, conn, ref} = Mint.HTTP.request(conn, "GET", resource, req_headers, nil)
+
+    {:ok, conn, ref} = Mint.WebSocket.upgrade(conn, resource, [])
     http_get_message = receive(do: (message -> message))
 
     {:ok, conn, [{:status, ^ref, status}, {:headers, ^ref, resp_headers}, {:done, ^ref}]} =
       Mint.HTTP.stream(conn, http_get_message)
 
-    {:ok, conn, websocket} = Mint.WebSocket.new(conn, ref, status, req_headers, resp_headers)
+    {:ok, conn, websocket} = Mint.WebSocket.new(conn, ref, status, resp_headers)
 
     %__MODULE__{
       next: :cont,

--- a/test/mint/web_socket_test.exs
+++ b/test/mint/web_socket_test.exs
@@ -6,14 +6,14 @@ defmodule Mint.WebSocketTest do
       # bootstrap
       host = System.get_env("ECHO_HOST") || "localhost"
       {:ok, conn} = Mint.HTTP.connect(:http, host, 9000)
-      req_headers = Mint.WebSocket.build_request_headers()
-      {:ok, conn, ref} = Mint.HTTP.request(conn, "GET", "/", req_headers, nil)
+
+      {:ok, conn, ref} = Mint.WebSocket.upgrade(conn, "/", [])
       assert_receive http_get_message
 
       {:ok, conn, [{:status, ^ref, status}, {:headers, ^ref, resp_headers}, {:done, ^ref}]} =
         Mint.HTTP.stream(conn, http_get_message)
 
-      {:ok, conn, websocket} = Mint.WebSocket.new(conn, ref, status, req_headers, resp_headers)
+      {:ok, conn, websocket} = Mint.WebSocket.new(conn, ref, status, resp_headers)
 
       # send the hello world frame
       {:ok, websocket, data} = Mint.WebSocket.encode(websocket, {:text, "hello world"})


### PR DESCRIPTION
diverges from the API discussed here: https://github.com/elixir-mint/mint/issues/106#issuecomment-470515281 to

- remove `build_request_headers/0`
- add `upgrade/4`

The bootstrapping process for WebSocket differs between HTTP/1 and HTTP/2 connections. HTTP/1 uses a GET with special headers to 'upgrade' the connection while HTTP/2 uses an extended CONNECT request to open a stream as a WebSocket connection. `upgrade/4` provides a thin wrapper around `Mint.HTTP.request/5` which performs the correct method and sets up the proper headers for HTTP/1 or HTTP/2.

A nice aspect of this is that we have a good place to store the `sec-websocket-key` header's value in the `Mint.HTTP1` conn, which removes the need to pass the request headers to `Mint.WebSocket.new/5` (which is now `Mint.WebSocket.new/4`). This may also serve as a good place to store extensions in `conn.private` when extensions are added.
