### PR TITLE
implement extensions and permessage-deflate

### DIFF
--- a/autobahn/config/fuzzingserver.json
+++ b/autobahn/config/fuzzingserver.json
@@ -2,9 +2,6 @@
   "url": "ws://0.0.0.0:9001",
   "outdir": "./reports",
   "cases": ["*"],
-  "exclude-cases": [
-    "12.*",
-    "13.*"
-  ],
+  "exclude-cases": [],
   "exclude-agent-cases": {}
 }

--- a/lib/mint/web_socket/extension.ex
+++ b/lib/mint/web_socket/extension.ex
@@ -1,0 +1,274 @@
+defmodule Mint.WebSocket.Extension do
+  @moduledoc """
+  Tools for defining extensions to the WebSocket protocol
+
+  The WebSocket protocol allows for extensions which act as middle-ware
+  in the encoding and decoding of frames. In `Mint.WebSocket`, extensions are
+  written as module which implement the `Mint.WebSocket.Extension` behaviour.
+
+  The common "permessage-deflate" extension is built-in to `Mint.WebSocket` as
+  `Mint.WebSocket.PerMessageDeflate`. This extension should be used as a
+  reference when writing future extensions, but future extensions should be
+  written as separate libraries which extend `Mint.WebSocket` instead of
+  built-in. Also note that extensions must operate on the internal
+  representations of frames using the records defined in `Mint.WebSocket.Frame`,
+  which are not documented.
+  """
+
+  alias Mint.WebSocketError
+
+  @typedoc """
+  Parameters to configure an extension
+
+  Some extensions can be configured by negotiation between the client and
+  server. For example "permessage-deflate" usually shows up as in the
+  "sec-websocket-extensions" header literally like so:
+
+  ```text
+  Sec-WebSocket-Extensions: permessage-deflate
+  ```
+
+  But the zlib window sizes and reset behavior can be negotiated with parameters
+  with headers like so
+
+  ```text
+  Sec-WebSocket-Extensions: permessage-deflate; client_no_context_takeover; client_max_window_bits=12
+  ```
+
+  These can be configured by passing parameters to any element passed in the
+  `:extensions` option to `Mint.WebSocket.upgrade/4`.
+
+  For example, one might write the above parameter configuration as
+
+  ```elixir
+  [
+    {Mint.WebSocket.PerMessageDeflate,
+     [client_no_context_takeover: true, client_max_window_bits: 12]}
+  ]
+  ```
+
+  when passing the `:extensions` option to `Mint.WebSocket.upgrade/4`.
+
+  Note that `Mint.WebSocket.upgrade/4` will normalize the parameters of an
+  extension to a list of two-tuples with string keys and values. For example,
+  the above would be normalized to this extensions list:
+
+  ```elixir
+  [
+    %Mint.WebSocket.Extension{
+      name: "permessage-deflate",
+      module: Mint.WebSocket.PerMessageDeflate,
+      params: [
+        {"client_no_context_takeover", "true"},
+        {"client_max_window_bits", "12"}
+      ],
+      state: nil,
+      opts: []
+    }
+  ]
+  ```
+  """
+  @type params :: [atom() | String.t() | {atom() | String.t(), boolean() | String.t()}]
+
+  @typedoc """
+  A structure representing an instance of an extension
+
+  Extensions are implemented as modules but passed to `Mint.WebSocket` as
+  `Mint.WebSocket.Extension` structs with the following keys:
+
+  * `:name` - the name of the extension. When using the short-hand tuple
+    syntax to pass extensions to `Mint.WebSocket.upgrade/4`, the name is
+    determined by calling the `c:name/0` callback.
+  * `:module` - the module which implements the callbacks defined in the
+    `Mint.WebSocket.Extension` behavior.
+  * `:state` - an arbitrary piece of data curated by the extension. For
+    example, the "permessage-deflate" extension uses this field to
+    hold `t:zlib.zstream()`s for compression and decompression.
+  * `:params` - a list with key-value tuples or atom/string keys which configure
+    the parameters communicated to the server. All params are encoded into the
+    "sec-websocket-extensions" header. Also see the documentation for
+    `t:params/0`.
+  * `:opts` - a keyword list to pass configuration to the extension. These
+    are not encoded into the "sec-websocket-extensions" header. For example,
+    `:opts` is used by the "permessage-deflate" extension to configure `:zlib`
+    configuration.
+  """
+  @type t :: %__MODULE__{
+          name: String.t(),
+          module: module(),
+          state: term(),
+          params: params(),
+          opts: Keyword.t()
+        }
+
+  @doc """
+  Returns the name of the WebSocket extension
+
+  This should not include the parameters for the extension, such as
+  "client_max_window_bits" for the "permessage-deflate" extension.
+
+  ## Examples
+
+      iex> Mint.WebSocket.PerMessageDeflate.name()
+      "permessage-deflate"
+  """
+  @callback name() :: String.t()
+
+  @doc """
+  Invoked when the WebSocket server accepts an extension
+
+  This callback should be used to initialize any `:state` that the extension
+  needs to operate. For example, this callback is used by the
+  "permessage-deflate" extension to setup `t::zlib.zstream()`s and store
+  them in state.
+
+  The `all_extensions` argument is passed so that the extension can know
+  about the existence and ordering of other extensions. This can be useful
+  if a client declares multiple extensions which accomplish the same job
+  (such as multiple compression extensions) but want to only enable one based
+  on what the server accepts.
+
+  Note that extensions are initialized in the order in which the server accepts
+  them: any extensions preceeding `this_extension` in `all_extensions` are
+  initialized while any extensions after `this_extension` are not yet
+  initialized.
+
+  Error tuples bubble up to `Mint.WebSocket.upgrade/4`.
+  """
+  @callback init(this_extension :: t(), all_extensions :: t()) :: {:ok, t()} | {:error, term()}
+
+  @doc """
+  Invoked when encoding frames before sending them across the wire
+
+  Error tuples bubble up to `Mint.WebSocket.encode/2`.
+  """
+  @callback encode(frame :: tuple(), state :: term()) ::
+              {:ok, frame :: tuple(), state :: term()} | {:error, term()}
+
+  @doc """
+  Invoked when decoding frames after receiving them from the wire
+
+  Error tuples bubble up to `Mint.WebSocket.decode/2`.
+  """
+  @callback decode(frame :: tuple(), state :: term()) ::
+              {:ok, frame :: tuple(), state :: term()} | {:error, term()}
+
+  defstruct [:name, :module, :state, opts: [], params: []]
+
+  @doc false
+  @spec encode(tuple(), [t()]) :: {:ok, tuple(), [t()]} | {:error, term()}
+  def encode(frame, extensions) do
+    encoded_or_error =
+      Enum.reduce_while(extensions, {:ok, frame, []}, fn extension, {:ok, frame, acc} ->
+        case extension.module.encode(frame, extension.state) do
+          {:ok, frame, state} ->
+            {:cont, {:ok, frame, [put_in(extension.state, state) | acc]}}
+
+          {:error, reason} ->
+            {:halt, {:error, reason}}
+        end
+      end)
+
+    with {:ok, frame, extensions} <- encoded_or_error do
+      {:ok, frame, :lists.reverse(extensions)}
+    end
+  end
+
+  @doc false
+  @spec decode(tuple(), [t()]) :: {:ok, tuple(), [t()]} | {:error, term()}
+  def decode(frame, extensions) do
+    {frame, extensions} =
+      Enum.reduce(extensions, {frame, []}, fn extension, {frame, acc} ->
+        case extension.module.decode(frame, extension.state) do
+          {:ok, frame, state} ->
+            {frame, [put_in(extension.state, state) | acc]}
+
+          {:error, reason} ->
+            throw({:mint, reason})
+        end
+      end)
+
+    {frame, :lists.reverse(extensions)}
+  end
+
+  @doc false
+  def accept_extensions(client_extensions, response_headers) do
+    server_extensions = parse_accepted_extensions(response_headers)
+    client_extension_mapping = Enum.into(client_extensions, %{}, &{&1.name, &1})
+
+    _accept_extensions(server_extensions, [], client_extension_mapping)
+  end
+
+  defp _accept_extensions(server_extension, acc, client_extension_mapping)
+
+  defp _accept_extensions([], acc, _), do: {:ok, :lists.reverse(acc)}
+
+  defp _accept_extensions([server_extension | server_extensions], acc, client_extension_mapping) do
+    with {:ok, client_extension} <-
+           Map.fetch(client_extension_mapping, server_extension.name),
+         extension = %__MODULE__{client_extension | params: server_extension.params},
+         all_extensions = acc ++ [extension | server_extensions],
+         {:ok, extension} <- client_extension.module.init(extension, all_extensions) do
+      _accept_extensions(
+        server_extensions,
+        acc ++ [extension],
+        client_extension_mapping
+      )
+    else
+      :error ->
+        {:error, %WebSocketError{reason: {:extension_not_negotiated, server_extension}}}
+
+      init_error ->
+        init_error
+    end
+  end
+
+  # There may be multiple sec-websocket-extension headers and these
+  # should be treated as separate items, or many extensions may be declared
+  # in one header.
+  #
+  # As [the RFC](https://datatracker.ietf.org/doc/html/rfc6455#section-9.1)
+  # says:
+  #
+  # Note that like other HTTP header fields, this header field MAY be
+  # split or combined across multiple lines.  Ergo, the following are
+  # equivalent:
+  #
+  #       Sec-WebSocket-Extensions: foo
+  #       Sec-WebSocket-Extensions: bar; baz=2
+  #
+  # is exactly equivalent to
+  #
+  #       Sec-WebSocket-Extensions: foo, bar; baz=2
+  defp parse_accepted_extensions(response_headers) do
+    response_headers
+    |> Enum.flat_map(fn
+      {"sec-websocket-extensions", extension_string} ->
+        extension_string
+        |> String.split(", ")
+        |> Enum.map(&parse_extension/1)
+
+      _ ->
+        []
+    end)
+  end
+
+  defp parse_extension(extension_string) do
+    [name | params] = String.split(extension_string, ";")
+
+    params =
+      Enum.map(params, fn param ->
+        param_tokens =
+          param
+          |> String.trim()
+          |> String.split("=", parts: 2)
+
+        case param_tokens do
+          [param] -> {param, "true"}
+          [param, value] -> {param, value}
+        end
+      end)
+
+    %__MODULE__{name: name, params: params}
+  end
+end

--- a/lib/mint/web_socket/frame.ex
+++ b/lib/mint/web_socket/frame.ex
@@ -389,6 +389,8 @@ defmodule Mint.WebSocket.Frame do
   end
 
   defp encode_close(code, reason) do
+    code = code || 1_000
+    reason = reason || ""
     <<code::unsigned-integer-size(8)-unit(2), reason::binary>>
   end
 

--- a/lib/mint/web_socket/per_message_deflate.ex
+++ b/lib/mint/web_socket/per_message_deflate.ex
@@ -1,0 +1,169 @@
+defmodule Mint.WebSocket.PerMessageDeflate do
+  @moduledoc """
+  A WebSocket extension which compresses each message before sending it across
+  the wire
+
+  This extension is defined in
+  [rfc7692](https://www.rfc-editor.org/rfc/rfc7692.html).
+
+  ## Options
+
+  * `:zlib_level` - (default: `:best_compression`) the compression level to
+    use for the deflation zstream. See the `:zlib.deflateInit/6` documentation
+    on the `Level` argument.
+  * `:zlib_memory_level` - (default: `8`) how much memory to allow for use
+    during compression. See the `:zlib.deflateInit/6` documentation on the
+    `MemLevel` argument.
+  """
+
+  require Mint.WebSocket.Frame, as: Frame
+  alias Mint.WebSocket.Extension
+
+  @doc false
+  @type t :: %__MODULE__{inflate: :zlib.zstream(), deflate: :zlib.zstream()}
+
+  defstruct [:inflate, :deflate, :inflate_takeover?, :deflate_takeover?]
+
+  @behaviour Extension
+
+  @doc false
+  @impl Extension
+  def name, do: "permessage-deflate"
+
+  @doc false
+  @impl Extension
+  def init(%Extension{params: params, opts: opts} = this_extension, _other_extensions) do
+    inflate_window_bits = get_window_bits(params, "client_max_window_bits", 15)
+    deflate_window_bits = get_window_bits(params, "server_max_window_bits", 15)
+    inflate_zstream = :zlib.open()
+    deflate_zstream = :zlib.open()
+
+    :ok = :zlib.inflateInit(inflate_zstream, -inflate_window_bits)
+
+    :ok =
+      :zlib.deflateInit(
+        deflate_zstream,
+        Keyword.get(opts, :zlib_level, :best_compression),
+        :deflated,
+        -deflate_window_bits,
+        Keyword.get(opts, :zlib_memory_level, 8),
+        :default
+      )
+
+    state = %__MODULE__{
+      inflate: inflate_zstream,
+      deflate: deflate_zstream,
+      inflate_takeover?: get_takeover(params, "server_no_context_takeover", false),
+      deflate_takeover?: get_takeover(params, "client_no_context_takeover", false)
+    }
+
+    {:ok, put_in(this_extension.state, state)}
+  end
+
+  @doc false
+  @impl Extension
+  def decode(frame, state)
+
+  for opcode <- [:text, :binary, :continuation] do
+    def decode(
+          Frame.unquote(opcode)(
+            reserved: <<1::size(1), _::bitstring>> = reserved_binary,
+            data: data
+          ) = frame,
+          state
+        ) do
+      <<reserved::size(3)>> = reserved_binary
+
+      # Append 4 octets of 0x00 0x00 0xff 0xff to the tail end of the
+      # payload of the message
+
+      data =
+        state.inflate
+        |> :zlib.inflate(<<data::binary, 0x00, 0x00, 0xFF, 0xFF>>)
+        |> IO.iodata_to_binary()
+
+      if state.inflate_takeover? == false do
+        :zlib.inflateReset(state.inflate)
+      end
+
+      frame =
+        Frame.unquote(opcode)(frame,
+          reserved: <<Bitwise.bxor(reserved, 0b100)::size(3)>>,
+          data: data
+        )
+
+      {:ok, frame, state}
+    end
+  end
+
+  def decode(frame, state), do: {:ok, frame, state}
+
+  @doc false
+  @impl Extension
+  def encode(frame, state)
+
+  for opcode <- [:text, :binary, :continuation] do
+    def encode(
+          Frame.unquote(opcode)(
+            reserved: <<0::size(1), _::bitstring>> = reserved_binary,
+            data: data
+          ) = frame,
+          state
+        ) do
+      <<reserved::size(3)>> = reserved_binary
+
+      data = deflate_data(state.deflate, data)
+
+      if state.deflate_takeover? == false do
+        :zlib.deflateReset(state.deflate)
+      end
+
+      frame =
+        Frame.unquote(opcode)(frame,
+          reserved: <<Bitwise.bor(reserved, 0b100)::size(3)>>,
+          data: data
+        )
+
+      {:ok, frame, state}
+    end
+  end
+
+  def encode(frame, state), do: {:ok, frame, state}
+
+  defp deflate_data(deflate_zstream, data) do
+    deflated =
+      deflate_zstream
+      |> :zlib.deflate(data, :sync)
+      |> IO.iodata_to_binary()
+
+    # "Remove 4 octets (that are 0x00 0x00 0xff 0xff) from the tail end"
+    data_size = byte_size(deflated) - 4
+
+    case deflated do
+      <<deflated::binary-size(data_size), 0x00, 0x00, 0xFF, 0xFF>> -> deflated
+      deflated -> deflated
+    end
+  end
+
+  defp get_window_bits(params, param_name, default) do
+    with value when is_binary(value) <- List.keyfind(params, param_name, 0, to_string(default)),
+         {bits, _} <- Integer.parse(value) do
+      bits
+    else
+      _ -> default
+    end
+  end
+
+  defp get_takeover(params, param_name, default) when is_boolean(default) do
+    with value when is_binary(value) <- List.keyfind(params, param_name, 0, to_string(default)),
+         {:ok, no_takeover?} <- parse_boolean(value) do
+      not no_takeover?
+    else
+      _ -> default
+    end
+  end
+
+  defp parse_boolean("true"), do: {:ok, true}
+  defp parse_boolean("false"), do: {:ok, false}
+  defp parse_boolean(_), do: :error
+end

--- a/lib/mint/web_socket/per_message_deflate.ex
+++ b/lib/mint/web_socket/per_message_deflate.ex
@@ -64,6 +64,8 @@ defmodule Mint.WebSocket.PerMessageDeflate do
   @impl Extension
   def decode(frame, state)
 
+  # rfc section 6: "[Per-Message Compression Extensions]s operate only on data
+  # messages"
   for opcode <- [:text, :binary, :continuation] do
     def decode(
           Frame.unquote(opcode)(

--- a/test/fixtures/h2cowboy/ws_h.erl
+++ b/test/fixtures/h2cowboy/ws_h.erl
@@ -4,8 +4,8 @@
 -export([websocket_init/1]).
 -export([websocket_handle/2]).
 
-init(Req, Opts) ->
-  {cowboy_websocket, Req, Opts}.
+init(Req, State) ->
+  {cowboy_websocket, Req, State, #{compress => true}}.
 
 websocket_init(State) ->
   {[], State}.

--- a/test/mint/web_socket/autobahn_test.exs
+++ b/test/mint/web_socket/autobahn_test.exs
@@ -9,6 +9,21 @@ defmodule Mint.WebSocket.AutobahnTest do
   @moduletag :autobahn
   @moduletag :capture_log
 
+  @extensions [
+    {~r"^12\.", [Mint.WebSocket.PerMessageDeflate]},
+    {~r"^13\.",
+     [
+       {Mint.WebSocket.PerMessageDeflate,
+        [client_no_context_takeover: true, client_max_window_bits: true]}
+     ]},
+    {~r/.*/, []}
+  ]
+
+  @test_tags [
+    {~r"^9\.", :performance},
+    {~r"^1(2|3)\.", :compression}
+  ]
+
   setup_all do
     on_exit(&AutobahnClient.update_reports/0)
   end
@@ -17,15 +32,23 @@ defmodule Mint.WebSocket.AutobahnTest do
     for case_number <- Range.new(1, AutobahnClient.get_case_count()) do
       info = Task.await(Task.async(fn -> AutobahnClient.get_case_info(case_number) end))
 
-      if String.starts_with?(info.id, "9.") do
-        @tag :performance
+      if tag =
+           Enum.find_value(@test_tags, fn {regex, tag} -> Regex.match?(regex, info.id) && tag end) do
+        @tag tag
       end
 
       test inspect("case #{info.id} (##{case_number}): #{info.description}", printable_limit: 200) do
-        assert AutobahnClient.run_case(unquote(case_number)) == :ok
+        extensions = extensions_for_case(unquote(info.id))
+        assert AutobahnClient.run_case(unquote(case_number), extensions) == :ok
 
         assert AutobahnClient.get_case_status(unquote(case_number)) in ~w[OK NON-STRICT INFORMATIONAL]
       end
     end
+  end
+
+  defp extensions_for_case(case_id) do
+    Enum.find_value(@extensions, fn {id_regex, extensions} ->
+      Regex.match?(id_regex, case_id) && extensions
+    end)
   end
 end

--- a/test/mint/web_socket_test.exs
+++ b/test/mint/web_socket_test.exs
@@ -57,7 +57,9 @@ defmodule Mint.WebSocketTest do
     end
 
     test "we can send and hello-world frame and receive an echo reply", %{conn: conn} do
-      {:ok, conn, ref} = Mint.WebSocket.upgrade(conn, "/", [])
+      {:ok, conn, ref} =
+        Mint.WebSocket.upgrade(conn, "/", [], extensions: [Mint.WebSocket.PerMessageDeflate])
+
       assert_receive http_connect_message
 
       {:ok, conn, [{:status, ^ref, status}, {:headers, ^ref, resp_headers}]} =


### PR DESCRIPTION
closes #1 

adds a functional interface for extensions (both meanings of "functional") and implements [rfc7692](https://www.rfc-editor.org/rfc/rfc7692.html) zip-based compression

it's notable that this makes the test suite take ~30min to run :facepalm: 

one passes a list of extension structs to the `Mint.WebSocket.upgrade/4` function in the `:extensions` option, with the syntax sugar of `[{extension_module, params}]` for short-hand

```elixir
Mint.WebSocket.upgrade(conn, "/", [], extensions: [Mint.WebSocket.PerMessageDeflate])
```

(or the even more syntax sugary `[extension_module]`)

not much documentation because I haven't included the whole documentation suite one needs to actually create the documentation