### PR TITLE
add fail-fast behavior for frames

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,3 @@
 import Config
 
-config :logger, level: :info
+# config :logger, level: :info

--- a/lib/mint/web_socket.ex
+++ b/lib/mint/web_socket.ex
@@ -371,7 +371,8 @@ defmodule Mint.WebSocket do
   {:ok, websocket, frames} = Mint.WebSocket.decode(websocket, data)
   ```
   """
-  @spec decode(t(), data :: binary()) :: {:ok, t(), [frame() | {:error, term()}]} | {:error, t(), any()}
+  @spec decode(t(), data :: binary()) ::
+          {:ok, t(), [frame() | {:error, term()}]} | {:error, t(), any()}
   defdelegate decode(websocket, data), to: Frame
 
   # we re-open the request in the conn for HTTP1 connections because a :done

--- a/lib/mint/web_socket.ex
+++ b/lib/mint/web_socket.ex
@@ -119,12 +119,12 @@ defmodule Mint.WebSocket do
   """
   @opaque t :: %__MODULE__{
             extensions: [Extension.t()],
-            fragments: [tuple()],
+            fragment: tuple(),
             private: map(),
             buffer: binary()
           }
   defstruct extensions: [],
-            fragments: [],
+            fragment: nil,
             private: %{},
             buffer: <<>>
 

--- a/lib/mint/web_socket/frame.ex
+++ b/lib/mint/web_socket/frame.ex
@@ -396,7 +396,8 @@ defmodule Mint.WebSocket.Frame do
     resolve_fragments(websocket, rest, [{:error, reason} | acc])
   end
 
-  def resolve_fragments(websocket, [frame | rest], acc) when is_control(frame) and is_fin(frame) do
+  def resolve_fragments(websocket, [frame | rest], acc)
+      when is_control(frame) and is_fin(frame) do
     resolve_fragments(websocket, rest, [frame | acc])
   end
 
@@ -425,9 +426,9 @@ defmodule Mint.WebSocket.Frame do
 
   for type <- [:continuation, :text, :binary] do
     defp combine(
-          unquote(type)(data: frame_data) = frame,
-          continuation(data: continuation_data, fin?: fin?)
-        ) do
+           unquote(type)(data: frame_data) = frame,
+           continuation(data: continuation_data, fin?: fin?)
+         ) do
       unquote(type)(frame, data: Utils.maybe_concat(frame_data, continuation_data), fin?: fin?)
     end
   end

--- a/test/fixtures/autobahn_client.ex
+++ b/test/fixtures/autobahn_client.ex
@@ -94,6 +94,7 @@ defmodule AutobahnClient do
   end
 
   def decode_buffer(state) do
+    IO.inspect(state.buffer)
     case Mint.WebSocket.decode(state.websocket, state.buffer) do
       {:ok, websocket, messages} ->
         %__MODULE__{state | messages: messages, buffer: <<>>, websocket: websocket}
@@ -127,22 +128,28 @@ defmodule AutobahnClient do
     |> Map.put(:messages, [])
   end
 
-  defp handle_message(:close, state), do: handle_message({:close, 1000, ""}, state)
-
   defp handle_message({:close, _code, _reason}, state) do
     close(state, 1000, "")
   end
-
-  defp handle_message(:ping, state), do: handle_message({:ping, ""}, state)
 
   defp handle_message({:ping, data}, state) do
     send(state, {:pong, data})
   end
 
   # no-op on unsolicited pongs
-  defp handle_message(:pong, state), do: handle_message({:pong, ""}, state)
-
   defp handle_message({:pong, _body}, state), do: state
+
+  defp handle_message({:error, reason}, state) do
+    Logger.debug("Closing the connection because of a protocol error: #{inspect(reason)}")
+
+    code=
+      case reason do
+        {:invalid_utf8, _data} -> 1_007
+        _ -> 1_002
+      end
+
+    close(state, code, "")
+  end
 
   defp handle_message(frame, state), do: send(state, frame)
 

--- a/test/fixtures/autobahn_client.ex
+++ b/test/fixtures/autobahn_client.ex
@@ -94,7 +94,6 @@ defmodule AutobahnClient do
   end
 
   def decode_buffer(state) do
-    IO.inspect(state.buffer)
     case Mint.WebSocket.decode(state.websocket, state.buffer) do
       {:ok, websocket, messages} ->
         %__MODULE__{state | messages: messages, buffer: <<>>, websocket: websocket}

--- a/test/fixtures/autobahn_client.ex
+++ b/test/fixtures/autobahn_client.ex
@@ -141,7 +141,7 @@ defmodule AutobahnClient do
   defp handle_message({:error, reason}, state) do
     Logger.debug("Closing the connection because of a protocol error: #{inspect(reason)}")
 
-    code=
+    code =
       case reason do
         {:invalid_utf8, _data} -> 1_007
         _ -> 1_002

--- a/test/mint/web_socket/frame_test.exs
+++ b/test/mint/web_socket/frame_test.exs
@@ -7,6 +7,6 @@ defmodule Mint.WebSocket.FrameTest do
     assert text(fin?: true, data: "hello") |> is_fin()
     refute text(fin?: false, data: "hello") |> is_fin()
 
-    assert ping() |> is_fin()
+    assert ping(fin?: true) |> is_fin()
   end
 end

--- a/test/mint/web_socket_test.exs
+++ b/test/mint/web_socket_test.exs
@@ -34,7 +34,7 @@ defmodule Mint.WebSocketTest do
       # receive a pong frame
       assert_receive pong_message
       {:ok, conn, [{:data, ^ref, data}]} = Mint.HTTP.stream(conn, pong_message)
-      assert {:ok, websocket, [:pong]} = Mint.WebSocket.decode(websocket, data)
+      assert {:ok, websocket, [{:pong, ""}]} = Mint.WebSocket.decode(websocket, data)
 
       # send a close frame
       {:ok, websocket, data} = Mint.WebSocket.encode(websocket, :close)
@@ -43,7 +43,7 @@ defmodule Mint.WebSocketTest do
       # receive a close frame
       assert_receive close_message
       {:ok, conn, [{:data, ^ref, data}]} = Mint.HTTP.stream(conn, close_message)
-      assert {:ok, _websocket, [:close]} = Mint.WebSocket.decode(websocket, data)
+      assert {:ok, _websocket, [{:close, 1_000, ""}]} = Mint.WebSocket.decode(websocket, data)
 
       {:ok, _conn} = Mint.HTTP.close(conn)
     end
@@ -90,7 +90,7 @@ defmodule Mint.WebSocketTest do
       # receive a pong frame
       assert_receive pong_message
       {:ok, conn, [{:data, ^ref, data}]} = Mint.HTTP.stream(conn, pong_message)
-      assert {:ok, websocket, [:pong]} = Mint.WebSocket.decode(websocket, data)
+      assert {:ok, websocket, [{:pong, ""}]} = Mint.WebSocket.decode(websocket, data)
 
       # send a close frame
       {:ok, websocket, data} = Mint.WebSocket.encode(websocket, :close)
@@ -99,7 +99,7 @@ defmodule Mint.WebSocketTest do
       # receive a close frame
       assert_receive close_message
       {:ok, conn, [{:data, ^ref, data}, {:done, ^ref}]} = Mint.HTTP.stream(conn, close_message)
-      assert {:ok, _websocket, [:close]} = Mint.WebSocket.decode(websocket, data)
+      assert {:ok, _websocket, [{:close, 1_000, ""}]} = Mint.WebSocket.decode(websocket, data)
 
       {:ok, _conn} = Mint.HTTP.close(conn)
     end


### PR DESCRIPTION
changes some behavior of `Mint.WebSocket.decode/2`

- it may return error tuples as `{:ok, websocket, [{:error, reason}]}` for fully contained bu invalid frames, such as text frames that are UTF-8
    - this fixes some of the non-strict test cases
- frames are now no longer returned frome decode/2 in shorthand format

connects #6 