### PR TITLE
rewrite masking function to be tail-recursive and use binary matches

### DIFF
--- a/lib/mint/web_socket/frame.ex
+++ b/lib/mint/web_socket/frame.ex
@@ -134,19 +134,28 @@ defmodule Mint.WebSocket.Frame do
   # bytes (where the mask bytes repeat).
   # This is an "involution" function: applying the mask will mask
   # the data and applying the mask again will unmask it.
-  def apply_mask(payload, nil), do: payload
+  def apply_mask(payload, mask, acc \\ <<>>)
 
-  def apply_mask(payload, _mask = <<a, b, c, d>>) do
-    [a, b, c, d]
-    |> Stream.cycle()
-    |> Enum.reduce_while({payload, _acc = <<>>}, fn
-      _mask_key, {<<>>, acc} ->
-        {:halt, acc}
+  def apply_mask(payload, nil, _acc), do: payload
 
-      mask_key, {<<part_key::integer, payload_rest::binary>>, acc} ->
-        {:cont, {payload_rest, <<acc::binary, Bitwise.bxor(mask_key, part_key)::integer>>}}
-    end)
+  # n=4 is the happy path
+  # n=3..1 catches cases where the remaining byte_size/1 of the payload is shorter
+  # than the mask
+  for n <- 4..1 do
+    def apply_mask(
+          <<part_key::integer-size(8)-unit(unquote(n)), payload_rest::binary>>,
+          <<mask_key::integer-size(8)-unit(unquote(n)), _::binary>> = mask,
+          acc
+        ) do
+      apply_mask(
+        payload_rest,
+        mask,
+        <<acc::binary, Bitwise.bxor(mask_key, part_key)::integer-size(8)-unit(unquote(n))>>
+      )
+    end
   end
+
+  def apply_mask(<<>>, _mask, acc), do: acc
 
   @spec decode(Mint.WebSocket.t(), binary()) ::
           {:ok, Mint.WebSocket.t(), [Mint.WebSocket.frame() | {:error, term()}]}

--- a/lib/mint/web_socket/frame.ex
+++ b/lib/mint/web_socket/frame.ex
@@ -8,6 +8,8 @@ defmodule Mint.WebSocket.Frame do
   alias Mint.WebSocket.{Utils, Extension}
   alias Mint.WebSocketError
 
+  @compile {:inline, apply_mask: 2, apply_mask: 3}
+
   shared = [{:reserved, <<0::size(3)>>}, :mask, :data, :fin?]
 
   defrecord :continuation, shared


### PR DESCRIPTION
closes #16 

saw these results with benchee:

```
Operating System: Linux
CPU Information: Intel(R) Core(TM) i7-9700KF CPU @ 3.60GHz
Number of Available Cores: 8
Available memory: 31.30 GB
Elixir 1.12.1
Erlang 24.0

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 10 s
memory time: 2 s
parallel: 1
inputs: none specified
Estimated total run time: 28 s

Benchmarking match...
Benchmarking stream...

Name             ips        average  deviation         median         99th %
match        10.11 K       98.91 μs    ±19.70%       96.12 μs      203.03 μs
stream        1.95 K      511.57 μs     ±5.05%      505.31 μs      623.51 μs

Comparison: 
match        10.11 K
stream        1.95 K - 5.17x slower +412.66 μs

Memory usage statistics: 

Name      Memory usage
match          0.38 MB
stream         2.06 MB - 5.39x memory usage +1.68 MB

**All measurements for memory usage were the same**
```

<details><summary>the bench file</summary>

```elixir
Mix.install([:benchee])

defmodule Foo do
  def stream_mask(payload, <<a, b, c, d>>) do
    [a, b, c, d]
    |> Stream.cycle()
    |> Enum.reduce_while({payload, _acc = <<>>}, fn
      _mask_key, {<<>>, acc} ->
        {:halt, acc}

      mask_key, {<<part_key::integer, payload_rest::binary>>, acc} ->
        {:cont, {payload_rest, <<acc::binary, Bitwise.bxor(mask_key, part_key)::integer>>}}
    end)
  end

  def match_mask(payload, mask, acc \\ <<>>)

  def match_mask(payload, nil, _acc), do: payload

  # n=4 is the happy path
  # n=3..1 catches cases where the remaining byte_size/1 of the payload is shorter
  # than the mask
  for n <- 4..1 do
    def match_mask(
          <<part_key::integer-size(8)-unit(unquote(n)), payload_rest::binary>>,
          <<mask_key::integer-size(8)-unit(unquote(n)), _::binary>> = mask,
          acc
        ) do
      match_mask(
        payload_rest,
        mask,
        <<acc::binary, Bitwise.bxor(mask_key, part_key)::integer-size(8)-unit(unquote(n))>>
      )
    end
  end

  def match_mask(<<>>, _mask, acc), do: acc
end

payload = :crypto.strong_rand_bytes(10_000)
mask = :crypto.strong_rand_bytes(4)

Benchee.run(
  %{
    "stream" => fn -> Foo.stream_mask(payload, mask) end,
    "match" => fn -> Foo.match_mask(payload, mask) end
  },
  time: 10,
  memory_time: 2
)
```

</details>

woof that was a lot of memory consumption beforehand!

---

#### what's this masking function?

When the client sends frames to the server, it "mask"s the payloads of the frames using 4 random bytes. The "mask" operation is that you take each byte of the mask and XOR it with a byte of the payload. When you reach the end of the mask bytes, you repeat the mask. When you reach the end of the payload, you're done!

From [RFC6455 section 5.3 on masking](https://datatracker.ietf.org/doc/html/rfc6455#section-5.3):

```
Octet i of the transformed data ("transformed-octet-i") is the XOR of
octet i of the original data ("original-octet-i") with octet at index
i modulo 4 of the masking key ("masking-key-octet-j"):

     j                   = i MOD 4
     transformed-octet-i = original-octet-i XOR masking-key-octet-j
```

I don't quite remember why we do this (cache busting, some outdated idea of a security mechanism, etc.), but we do this often, so might as well make it efficient.