### PR TITLE
fix: use :erlang.bxor/2 instead of Bitwise.bxor/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.2 - 2021-07-02
+
+### Fixed
+
+- Switch from using `Bitwise.bxor/2` to `:erlang.bxor/2` for compatibility
+  with Elixir < 1.10
+
 ## 0.1.1 - 2021-07-01
 
 ### Fixed

--- a/lib/mint/web_socket/frame.ex
+++ b/lib/mint/web_socket/frame.ex
@@ -156,7 +156,7 @@ defmodule Mint.WebSocket.Frame do
       apply_mask(
         payload_rest,
         mask,
-        <<acc::binary, Bitwise.bxor(mask_key, part_key)::integer-size(8)-unit(unquote(n))>>
+        <<acc::binary, :erlang.bxor(mask_key, part_key)::integer-size(8)-unit(unquote(n))>>
       )
     end
   end

--- a/lib/mint/web_socket/per_message_deflate.ex
+++ b/lib/mint/web_socket/per_message_deflate.ex
@@ -90,7 +90,7 @@ defmodule Mint.WebSocket.PerMessageDeflate do
 
       frame =
         Frame.unquote(opcode)(frame,
-          reserved: <<Bitwise.bxor(reserved, 0b100)::size(3)>>,
+          reserved: <<:erlang.bxor(reserved, 0b100)::size(3)>>,
           data: data
         )
 


### PR DESCRIPTION
<details><summary>Looks like this function used to be a macro in elixir < 1.10...</summary>

```
michael@mango ~> nix-shell -p elixir_1_9
these paths will be fetched (3.29 MiB download, 5.37 MiB unpacked):
  /nix/store/ds8swb2gz7wmlncwm3bx8aj7mxrxkngi-elixir-1.9.4
copying path '/nix/store/ds8swb2gz7wmlncwm3bx8aj7mxrxkngi-elixir-1.9.4' from 'https://cache.nixos.org'...

[nix-shell:~]$ iex
Erlang/OTP 23 [erts-11.2.2] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [hipe]

Interactive Elixir (1.9.4) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> Bitwise.__info__(:functions)
[]
iex(2)> Bitwise.__info__(:macros)   
[
  &&&: 2,
  <<<: 2,
  >>>: 2,
  ^^^: 2,
  __using__: 1,
  band: 2,
  bnot: 1,
  bor: 2,
  bsl: 2,
  bsr: 2,
  bxor: 2,
  |||: 2,
  ~~~: 1
]
iex(3)> 
BREAK: (a)bort (A)bort with dump (c)ontinue (p)roc info (i)nfo
       (l)oaded (v)ersion (k)ill (D)b-tables (d)istribution
^C
[nix-shell:~]$ exit
michael@mango ~> nix-shell -p elixir_1_10
these paths will be fetched (3.53 MiB download, 5.89 MiB unpacked):
  /nix/store/xgfbgv3lr9vp6jsqr34pk8bq2dviazsx-elixir-1.10.4
copying path '/nix/store/xgfbgv3lr9vp6jsqr34pk8bq2dviazsx-elixir-1.10.4' from 'https://cache.nixos.org'...

[nix-shell:~]$ iex
Erlang/OTP 23 [erts-11.2.2] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [hipe]

Interactive Elixir (1.10.4) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> Bitwise.__info__(:functions)
[
  &&&: 2,
  <<<: 2,
  >>>: 2,
  ^^^: 2,
  band: 2,
  bnot: 1,
  bor: 2,
  bsl: 2,
  bsr: 2,
  bxor: 2,
  |||: 2,
  ~~~: 1
]
iex(2)> Bitwise.__info__(:macros)   
[__using__: 1]
```

</details>

Here's the commit that changed it from macros to functions: https://github.com/elixir-lang/elixir/commit/1e4e05ef78b3105065f0a313bd0e1e78b2aa973e#diff-032f258b047753a20ce7dbe83d825bbf440b74bae27967d6f06eda11d379680e

No need to die on this hill and declare only `~> 1.10` compatibility: might as well just call the erlang functions like the stdlib does